### PR TITLE
Set dependency between each account creation

### DIFF
--- a/accounts.yaml
+++ b/accounts.yaml
@@ -77,6 +77,7 @@ Resources:
         Value: !Ref SSOUserEmail
       - Key: ManagedOrganizationalUnit
         Value: !Ref WorkloadsOrganizationalUnit
+    DependsOn: OperationsAccount
   ProductionAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
     Properties:
@@ -96,6 +97,7 @@ Resources:
         Value: !Ref SSOUserEmail
       - Key: ManagedOrganizationalUnit
         Value: !Ref WorkloadsOrganizationalUnit
+    DependsOn: SandboxAccount
   NetworkAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
     Properties:
@@ -115,6 +117,7 @@ Resources:
         Value: !Ref SSOUserEmail
       - Key: ManagedOrganizationalUnit
         Value: !Ref SharedOrganizationalUnit
+    DependsOn: ProductionAccount
   BackupAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
     Properties:
@@ -134,3 +137,4 @@ Resources:
         Value: !Ref SSOUserEmail
       - Key: ManagedOrganizationalUnit
         Value: !Ref SharedOrganizationalUnit
+    DependsOn: NetworkAccount


### PR DESCRIPTION
The cloudformation template crashes out with errors whenever the template is applied.
 
We observed it was crashing out because it was trying to create all the AWS accounts simultaneously, and the product catalog page showed it was already in use. 

This update will introduce a dependency between all resources so it only creates one account at a time.