### PR TITLE
Don't unenroll accounts on deletion

### DIFF
--- a/accounts.yaml
+++ b/accounts.yaml
@@ -41,6 +41,8 @@ Parameters:
 Resources:
   OperationsAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       ProductId: !Ref ProvisioningProductId
       ProvisionedProductName: Operations
@@ -60,6 +62,8 @@ Resources:
         Value: !Ref SharedOrganizationalUnit
   SandboxAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       ProductId: !Ref ProvisioningProductId
       ProvisionedProductName: Sandbox
@@ -80,6 +84,8 @@ Resources:
     DependsOn: OperationsAccount
   ProductionAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       ProductId: !Ref ProvisioningProductId
       ProvisionedProductName: Sandbox
@@ -100,6 +106,8 @@ Resources:
     DependsOn: SandboxAccount
   NetworkAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       ProductId: !Ref ProvisioningProductId
       ProvisionedProductName: Sandbox
@@ -120,6 +128,8 @@ Resources:
     DependsOn: ProductionAccount
   BackupAccount:
     Type: AWS::ServiceCatalog::CloudFormationProvisionedProduct
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       ProductId: !Ref ProvisioningProductId
       ProvisionedProductName: Sandbox


### PR DESCRIPTION
Currently, if somebody removes an account from the Cloudformation stack, it will be unenrolled from Control Tower. This sets policies to avoid automatic account removal so that accounts can be cleaned up and closed before unenrolling.
