### PR TITLE
Render account list as template

### DIFF
--- a/accounts.template.yaml
+++ b/accounts.template.yaml
@@ -3,14 +3,6 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Provision accounts using Control Tower account factory
 
 Parameters:
-  AccountEmailPrefix:
-    Description: "Prefix to apply to account emails"
-    Type: String
-    AllowedPattern : "[^\\s@]+"
-  AccountEmailSuffix:
-    Description: "Prefix to apply to account emails"
-    Type: String
-    AllowedPattern : "[^\\s@]*@[^\\s@]+\\.[^\\s@]+"
   SSOUserFirstName:
     Description:  "SSO user first name."
     Type: String
@@ -51,7 +43,7 @@ Resources:
       - Key: AccountName
         Value: Operations
       - Key: AccountEmail
-        Value: !Sub "${AccountEmailPrefix}operations${AccountEmailSuffix}"
+        Value: "__ACCOUNT_EMAIL_PREFIX__operations__ACCOUNT_EMAIL_SUFFIX__"
       - Key: SSOUserFirstName
         Value: !Ref SSOUserFirstName
       - Key: SSOUserLastName
@@ -72,7 +64,7 @@ Resources:
       - Key: AccountName
         Value: Sandbox
       - Key: AccountEmail
-        Value: !Sub "${AccountEmailPrefix}sandbox${AccountEmailSuffix}"
+        Value: "__ACCOUNT_EMAIL_PREFIX__sandbox__ACCOUNT_EMAIL_SUFFIX__"
       - Key: SSOUserFirstName
         Value: !Ref SSOUserFirstName
       - Key: SSOUserLastName
@@ -94,7 +86,7 @@ Resources:
       - Key: AccountName
         Value: Production
       - Key: AccountEmail
-        Value: !Sub "${AccountEmailPrefix}production${AccountEmailSuffix}"
+        Value: "__ACCOUNT_EMAIL_PREFIX__production__ACCOUNT_EMAIL_SUFFIX__"
       - Key: SSOUserFirstName
         Value: !Ref SSOUserFirstName
       - Key: SSOUserLastName
@@ -116,7 +108,7 @@ Resources:
       - Key: AccountName
         Value: Network
       - Key: AccountEmail
-        Value: !Sub "${AccountEmailPrefix}network${AccountEmailSuffix}"
+        Value: "__ACCOUNT_EMAIL_PREFIX__network__ACCOUNT_EMAIL_SUFFIX__"
       - Key: SSOUserFirstName
         Value: !Ref SSOUserFirstName
       - Key: SSOUserLastName
@@ -138,7 +130,7 @@ Resources:
       - Key: AccountName
         Value: Backup
       - Key: AccountEmail
-        Value: !Sub "${AccountEmailPrefix}backup${AccountEmailSuffix}"
+        Value: "__ACCOUNT_EMAIL_PREFIX__backup__ACCOUNT_EMAIL_SUFFIX__"
       - Key: SSOUserFirstName
         Value: !Ref SSOUserFirstName
       - Key: SSOUserLastName
@@ -160,7 +152,7 @@ Resources:
       - Key: AccountName
         Value: Identity
       - Key: AccountEmail
-        Value: !Sub "${AccountEmailPrefix}identity${AccountEmailSuffix}"
+        Value: "__ACCOUNT_EMAIL_PREFIX__identity__ACCOUNT_EMAIL_SUFFIX__"
       - Key: SSOUserFirstName
         Value: !Ref SSOUserFirstName
       - Key: SSOUserLastName

--- a/bin/provision-accounts
+++ b/bin/provision-accounts
@@ -11,6 +11,25 @@ if [ -f config.env ]; then
   export $(xargs < config.env)
 fi
 
+if [ ! -f "accounts.yaml" ]; then
+  echo "Generating account list..."
+  bin/render-template accounts.template.yaml accounts.yaml
+  rm accounts.template.yaml
+
+  printf "%s" "Edit accounts before deploying? (y/n) "
+  IFS= read -r line
+
+  if [ "$line" = "y" ]; then
+    if [ -z "$EDITOR" ]; then
+      echo "No \$EDITOR set." >&2
+      echo "Aborting" >&2
+      exit 1
+    fi
+
+    "$EDITOR" accounts.yaml
+  fi
+fi
+
 STACK_NAME="aws-control-tower-accounts"
 PRODUCT_NAME="AWS Control Tower Account Factory"
 
@@ -61,8 +80,6 @@ if [ "$DEPLOYED_STACK" = "$STACK_NAME" ]; then
     --parameters \
     "ParameterKey=ProvisioningProductId,ParameterValue=$PRODUCT_ID" \
     "ParameterKey=ProvisioningArtifactId,ParameterValue=$ARTIFACT_ID" \
-    "ParameterKey=AccountEmailPrefix,ParameterValue=$ACCOUNT_EMAIL_PREFIX" \
-    "ParameterKey=AccountEmailSuffix,ParameterValue=$ACCOUNT_EMAIL_SUFFIX" \
     "ParameterKey=SharedOrganizationalUnit,ParameterValue=$SHARED_OU" \
     "ParameterKey=WorkloadsOrganizationalUnit,ParameterValue=$WORKLOADS_OU" \
     "ParameterKey=SSOUserEmail,ParameterValue=$USER_EMAIL" \


### PR DESCRIPTION
The account list currently has the prefix/suffix interpolated into the template, which makes it hard to see what the actual email addresses are in production account lists.

This changes the scripts to render the account list as a template, allowing some values to be hard-coded into the final manifest so that you end up with more readable email addresses.
