### PR TITLE
Adjust trust policy ARN format to accommodate for ARNs including region

### DIFF
--- a/templates/terraform-hub-account.yaml
+++ b/templates/terraform-hub-account.yaml
@@ -71,7 +71,7 @@ Resources:
               Condition:
                 ArnLike:
                   "aws:PrincipalArn":
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${SSOPermissionSet}_*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_${SSOPermissionSet}_*"
 
   # Create SSM parameters to reference from Terraform
   OIDCProviderArn:

--- a/templates/terraform-spoke-account.yaml
+++ b/templates/terraform-spoke-account.yaml
@@ -99,7 +99,7 @@ Resources:
               Condition:
                 ArnLike:
                   "aws:PrincipalArn":
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${SSOPermissionSet}_*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_${SSOPermissionSet}_*"
 
   TerraformStateBackend:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
Not certain about why this occurs in certain cases, but I encountered a multi-account AWS setup where SSO ARNs are coming through with a region; eg:

```
arn:aws:iam::ACCT_ID:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_*
```

This PR accommodates for this variance in format by utilizing a second wildcard. Per [AWS documentation](https://docs.aws.amazon.com/quicksight/latest/APIReference/qs-arn-format.html), an asterisk will match zero or more characters. So this will work fine for both formats